### PR TITLE
Correction for left shift vs. plus operator precedence

### DIFF
--- a/Evt/Evt.py
+++ b/Evt/Evt.py
@@ -89,7 +89,7 @@ class SID_IDENTIFIER_AUTHORITY(Block, Nestable):
         return SID_IDENTIFIER_AUTHORITY.structure_size(self._buf, self.absolute_offset(0x0), None)
 
     def __str__(self):
-        return "%s" % (self.high_part() << 32 + self.low_part())
+        return "%s" % ((self.high_part() << 32) + self.low_part())
 
 
 class SID(Block, Nestable):


### PR DESCRIPTION
To ensure the the shift operator takes precedence over the plus operator.